### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Essential public facility data for AI agents helping foreign tourists in Seoul, South Korea.
 
+<a href="https://glama.ai/mcp/servers/@do-droid/seoul-essentials">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@do-droid/seoul-essentials/badge" alt="seoul-essentials MCP server" />
+</a>
+
 ## What is this?
 
 Seoul Essentials is an MCP (Model Context Protocol) server that provides structured data about essential public facilities in Seoul. Designed for AI agents that assist foreign tourists with real-time queries about nearby services.


### PR DESCRIPTION
This PR adds a badge for the [seoul-essentials](https://glama.ai/mcp/servers/@do-droid/seoul-essentials) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@do-droid/seoul-essentials">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@do-droid/seoul-essentials/badge" alt="seoul-essentials MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.